### PR TITLE
Improve external usability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(${PROJECT_NAME}
     src/giftWrap.cpp
     src/PLC.cpp
     src/delaunay.cpp
+	src/inputPLC.cpp
     src/main.cpp
 )
 

--- a/include/implicit_point.h
+++ b/include/implicit_point.h
@@ -442,42 +442,40 @@ public:
 //
 //////////////////////////////////////////////////////////////////////////////////////
 
-using namespace ::std;
+std::ostream& operator<<(std::ostream& os, const genericPoint& p);
 
-ostream& operator<<(ostream& os, const genericPoint& p);
-
-inline ostream& operator<<(ostream& os, const explicitPoint2D& p)
+inline std::ostream& operator<<(std::ostream& os, const explicitPoint2D& p)
 {
 	return os << p.X() << " " << p.Y() << " 0";
 }
 
-inline ostream& operator<<(ostream& os, const implicitPoint2D_SSI& p)
+inline std::ostream& operator<<(std::ostream& os, const implicitPoint2D_SSI& p)
 {
 	explicitPoint2D e;
 	if (p.apapExplicit(e)) return os << e;
 	else return os << "UNDEF_SSI";
 }
 
-inline ostream& operator<<(ostream& os, const explicitPoint3D& p)
+inline std::ostream& operator<<(std::ostream& os, const explicitPoint3D& p)
 {
 	return os << p.X() << " " << p.Y() << " " << p.Z();
 }
 
-inline ostream& operator<<(ostream& os, const implicitPoint3D_LPI& p)
+inline std::ostream& operator<<(std::ostream& os, const implicitPoint3D_LPI& p)
 {
 	explicitPoint3D e;
 	if (p.apapExplicit(e)) return os << e;
 	else return os << "UNDEF_LPI";
 }
 
-inline ostream& operator<<(ostream& os, const implicitPoint3D_TPI& p)
+inline std::ostream& operator<<(std::ostream& os, const implicitPoint3D_TPI& p)
 {
 	explicitPoint3D e;
 	if (p.apapExplicit(e)) return os << e;
 	else return os << "UNDEF_TPI";
 }
 
-inline ostream& operator<<(ostream& os, const implicitPoint3D_LNC& p)
+inline std::ostream& operator<<(std::ostream& os, const implicitPoint3D_LNC& p)
 {
 	explicitPoint3D e;
 	if (p.apapExplicit(e)) return os << e;

--- a/include/implicit_point.hpp
+++ b/include/implicit_point.hpp
@@ -922,7 +922,7 @@ inline bool implicitPoint3D_LNC::getExactXYZCoordinates(bigrational& x, bigratio
 	return true;
 }
 
-inline ostream& operator<<(ostream& os, const genericPoint& p)
+inline std::ostream& operator<<(std::ostream& os, const genericPoint& p)
 {
 	if (p.isExplicit2D()) return os << p.toExplicit2D();
 	else if (p.isExplicit3D()) return os << p.toExplicit3D();

--- a/src/delaunay.cpp
+++ b/src/delaunay.cpp
@@ -2,8 +2,6 @@
 #include <float.h>
 #include <iomanip>
 
-using namespace std;
-
 void TetMesh::init_vertices(const double* coords, uint32_t num_v) {
     vertices.reserve(num_v);
     for (uint32_t i = 0; i < num_v; i++)
@@ -74,7 +72,7 @@ void TetMesh::tetrahedrize() {
 
 bool TetMesh::saveTET(const char* filename, bool inner_only) const
 {
-    ofstream f(filename);
+    std::ofstream f(filename);
 
     if (!f) {
         std::cerr << "\nTetMesh::saveTET: Can't open file for writing.\n";
@@ -112,7 +110,7 @@ bool TetMesh::saveTET(const char* filename, bool inner_only) const
 
 bool TetMesh::saveVTU(const char* filename, bool inner_only) const
 {
-    ofstream f(filename);
+    std::ofstream f(filename);
     if (!f) {
         std::cerr << "\nTetMesh::saveVTU: Can't open file for writing.\n";
         return false;
@@ -179,7 +177,7 @@ bool TetMesh::saveVTU(const char* filename, bool inner_only) const
 
 bool TetMesh::saveMEDIT(const char* filename, bool inner_only) const
 {
-    ofstream f(filename);
+    std::ofstream f(filename);
 
     if (!f) {
         std::cerr << "\nTetMesh::saveMEDIT: Can't open file for writing.\n";
@@ -220,7 +218,7 @@ bool TetMesh::saveMEDIT(const char* filename, bool inner_only) const
 
 bool TetMesh::saveBinaryTET(const char* filename, bool inner_only) const
 {
-    ofstream f(filename, ios::binary);
+    std::ofstream f(filename, std::ios::binary);
 
     if (!f) {
         std::cerr << "\nTetMesh::saveBinaryTET: Can't open file for writing.\n";
@@ -266,7 +264,7 @@ bool TetMesh::saveBinaryTET(const char* filename, bool inner_only) const
 }
 
 bool TetMesh::saveBoundaryToOFF(const char* filename) const {
-    ofstream f(filename);
+    std::ofstream f(filename);
 
     if (!f) {
         std::cerr << "\nTetMesh::saveBoundaryToOFF: Can't open file for writing.\n";
@@ -298,7 +296,7 @@ bool TetMesh::saveBoundaryToOFF(const char* filename) const {
 bool TetMesh::saveRationalTET(const char* filename, bool inner_only)
 {
 #ifdef USE_INDIRECT_PREDS
-    ofstream f(filename);
+    std::ofstream f(filename);
 
     if (!f) {
         std::cerr << "\nTetMesh::saveRationalTET: Can't open file for writing.\n";
@@ -1364,7 +1362,7 @@ bool TetMesh::optimizeNearDegenerateTets(bool verbose) {
 bool TetMesh::collapseOnV1(uint32_t v1, uint32_t v2, bool prevent_inversion, double th_energy) {
     if (v1 == INFINITE_VERTEX || v2 == INFINITE_VERTEX) return false;
 
-    vector<uint64_t> vtf1, vtf2, v1nv, v2nv;
+    std::vector<uint64_t> vtf1, vtf2, v1nv, v2nv;
     bool v1_on_boundary = false, v2_on_boundary = false, e_on_boundary = false;
     VTfull(v1, vtf1);
     for (uint64_t t : vtf1) if (isGhost(t)) { v1_on_boundary = true; break; }

--- a/src/inputPLC.cpp
+++ b/src/inputPLC.cpp
@@ -1,5 +1,9 @@
 #include "inputPLC.h"
 
+#include <algorithm>
+#include <cfloat>
+#include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <fstream>
 

--- a/src/inputPLC.cpp
+++ b/src/inputPLC.cpp
@@ -1,0 +1,301 @@
+#include "inputPLC.h"
+
+#include <iostream>
+#include <fstream>
+
+#include "implicit_point.h"
+
+void reorderVertices(double* coordinates, uint32_t numVertices, uint32_t* triVertices, uint32_t numTriangles) {
+    std::vector<reVertex> revertices; 
+    revertices.reserve(numVertices);
+    for (uint32_t i = 0; i < numVertices; i++) revertices.push_back(reVertex(coordinates + (i * 3), i));
+
+    std::vector<vBlock> blocks;
+    blocks.push_back(vBlock(0, numVertices, 0));
+
+    for (uint32_t b = 0; b < blocks.size(); b++) {
+        const vBlock block = blocks[b];
+        const uint32_t dir_split = block.dir_split;
+        if (dir_split == 0) std::sort(revertices.begin() + block.begin, revertices.begin() + block.end, reVertex::lessThanOnX);
+        else if (dir_split == 1) std::sort(revertices.begin() + block.begin, revertices.begin() + block.end, reVertex::lessThanOnY);
+        else std::sort(revertices.begin() + block.begin, revertices.begin() + block.end, reVertex::lessThanOnZ);
+        const uint32_t block_mid = (block.begin + block.end) >> 1;
+        if (block_mid != block.begin && block_mid != block.end) {
+            blocks.push_back(vBlock(block.begin, block_mid, (dir_split + 1) % 3));
+            blocks.push_back(vBlock(block_mid, block.end, (dir_split + 1) % 3));
+        }
+    }
+
+    std::vector<uint32_t> new_index(numVertices);
+    for (uint32_t i = 0; i < numVertices; i++) new_index[revertices[i].index] = i;
+
+    for (uint32_t i = 0; i < numTriangles * 3; i++) triVertices[i] = new_index[triVertices[i]];
+    for (uint32_t i = 0; i < numVertices; i++) {
+        const double* pt = revertices[i].c;
+        coordinates[i * 3] = pt[0];
+        coordinates[i * 3 + 1] = pt[1];
+        coordinates[i * 3 + 2] = pt[2];
+    }
+}
+
+bool misAlignment(const double* p, const double* q, const double* r)
+{
+    return orient2d(p[0], p[1], q[0], q[1], r[0], r[1]) ||
+        orient2d(p[1], p[2], q[1], q[2], r[1], r[2]) ||
+        orient2d(p[0], p[2], q[0], q[2], r[0], r[2]);
+}
+
+void read_OFF_file(const char* filename,
+    double** vertices_p, uint32_t* npts,
+    uint32_t** tri_vertices_p, uint32_t* ntri, bool verbose) {
+
+    FILE* file = fopen(filename, "r");
+    if (file == NULL)
+        ip_error("read_OFF_file: FATAL ERROR "
+            "cannot open input file.\n");
+
+    // Check OFF mark (1st line).
+    char file_ext_read[3];
+    char file_ext_target[] = { 'O','F','F' };
+    if (fscanf(file, "%3c", file_ext_read) == 0)
+        ip_error("read_OFF_file: FATAL ERROR "
+            "cannot read 1st line of input file\n");
+
+    for (uint32_t i = 0; i < 3; i++)
+        if (file_ext_read[i] != file_ext_target[i])
+            ip_error("read_OFF_file: FATAL ERROR "
+                "1st line of input file is different from OFF\n");
+
+    // Reading number of points and triangles.
+    if (fscanf(file, " %d %d %*d ", npts, ntri) == 0)
+        ip_error("read_OFF_file: FATAL ERROR 2st line of "
+            "input file do not contanins point and triangles numbers.\n");
+
+    if (verbose) std::cout << "file " << filename << " contains " << *npts << " vertices and " << *ntri << " constraints (triangles)\n";
+
+    // Reading points coordinates.
+    *vertices_p = (double*)malloc(sizeof(double) * 3 * (*npts));
+    *tri_vertices_p = (uint32_t*)malloc(sizeof(uint32_t) * 3 * (*ntri));
+
+    for (uint32_t i = 0; i < (*npts); i++) {
+        if (fscanf(file, " %lf %lf %lf ",
+            (*vertices_p) + (i * 3), (*vertices_p) + (i * 3 + 1), (*vertices_p) + (i * 3 + 2)) == 0)
+            ip_error("error reading input file\n");
+    }
+
+    uint32_t nv;
+    for (uint32_t i = 0; i < (*ntri); i++) {
+        if (fscanf(file, " %u %u %u %u ", &nv,
+            (*tri_vertices_p) + (i * 3), (*tri_vertices_p) + (i * 3 + 1), (*tri_vertices_p) + (i * 3 + 2)) == 0)
+            ip_error("error reading input file\n");
+        if (nv != 3) ip_error("Non-triangular faces not supported\n");
+    }
+    fclose(file);
+}
+
+int vertex_compare(const void* void_v1, const void* void_v2)
+{
+    const input_vertex_t* v1 = (input_vertex_t*)void_v1;
+    const input_vertex_t* v2 = (input_vertex_t*)void_v2;
+    const double dx = v1->coord[0] - v2->coord[0];
+    const double dy = v1->coord[1] - v2->coord[1];
+    const double dz = v1->coord[2] - v2->coord[2];
+    return (4 * ((dx > 0) - (dx < 0)) +
+        2 * ((dy > 0) - (dy < 0)) +
+        ((dz > 0) - (dz < 0)));
+}
+
+int triOrder(const void* t1, const void* t2) {
+    const uint32_t* a = (uint32_t*)t1;
+    const uint32_t* b = (uint32_t*)t2;
+
+    // Here we should pre-order a[3] and b[3] to identify coincident triangles with different vertex ordering!!!
+    // To be done!
+    if (a[0] < b[0]) return -1;
+    if (a[0] > b[0]) return 1;
+    if (a[1] < b[1]) return -1;
+    if (a[1] > b[1]) return 1;
+    if (a[2] < b[2]) return -1;
+    return (a[2] > b[2]);
+}
+
+inline bool coincident_points(const input_vertex_t* a, const input_vertex_t* b)
+{
+    return !vertex_compare(a->coord, b->coord);
+}
+
+void remove_duplicated_points(input_vertex_t** vertices_p, uint32_t* npts,
+    input_vertex_t* vrts_copy,
+    uint32_t* map, uint32_t* diff) {
+
+    // Sorting vertices by coordinates lexicographic order (x,y,z)
+    qsort(vrts_copy, *npts, sizeof(input_vertex_t), vertex_compare);
+
+    // Count and memory position of duplicated vertices.
+    uint32_t vrts_counter = 0;
+    for (uint32_t i = 1; i < (*npts); i++) {
+        if (coincident_points(vrts_copy + i - 1, vrts_copy + i)) vrts_counter++;
+        diff[i] = vrts_counter;
+    }
+
+    // Set original_index to follow vertices permutation.
+    for (uint32_t i = 0; i < (*npts); i++)  map[vrts_copy[i].original_index] = i;
+
+    // Allocating memory to store uinque mesh vertices (vertices_p).
+    *vertices_p = (input_vertex_t*)malloc(sizeof(input_vertex_t) * (*npts - vrts_counter));
+
+    // Fill mesh vertices (vertices_p)
+    memcpy(*vertices_p, vrts_copy, sizeof(input_vertex_t));
+    for (uint32_t i = vrts_counter = 1; i < (*npts); i++)
+        if (!coincident_points(vrts_copy + i - 1, vrts_copy + i))
+            memcpy(*vertices_p + (vrts_counter++), vrts_copy + i, sizeof(input_vertex_t));
+
+    // Update uinque vertices number.
+    (*npts) = vrts_counter;
+}
+
+
+/// //////////////////////////////////////////////////////////////////////////////////////////
+
+void read_nodes_and_constraints(double* coords_A, uint32_t npts_A, uint32_t* tri_idx_A, uint32_t ntri_A,
+    input_vertex_t** vertices_p, uint32_t* npts,
+    uint32_t** tri_vertices_p, uint32_t* ntri, bool verbose) {
+
+    // Reading points coordinates.
+    *npts = npts_A;
+    *ntri = ntri_A;
+    input_vertex_t* tmp = (input_vertex_t*)malloc(*npts * sizeof(input_vertex_t));
+    uint32_t* diff = (uint32_t*)calloc(*npts, sizeof(uint32_t));
+    uint32_t* map = (uint32_t*)malloc(*npts * sizeof(uint32_t));
+    *tri_vertices_p = (uint32_t*)malloc(sizeof(uint32_t) * 3 * (*ntri));
+
+    for (uint32_t i = 0; i < (*npts); i++) {
+        tmp[i].coord[0] = coords_A[i * 3];
+        tmp[i].coord[1] = coords_A[i * 3 + 1];
+        tmp[i].coord[2] = coords_A[i * 3 + 2];
+        tmp[i].original_index = i;
+    }
+
+    if (*npts > 1) remove_duplicated_points(vertices_p, npts, tmp, map, diff);
+    if (verbose) std::cout << "Using " << *npts << " unique vertices\n";
+
+    free(tmp);
+
+    for (uint32_t i = 0, j = 0; i < (*ntri); j++) {
+
+        const uint32_t i1 = tri_idx_A[j * 3];
+        const uint32_t i2 = tri_idx_A[j * 3 + 1];
+        const uint32_t i3 = tri_idx_A[j * 3 + 2];
+        (*tri_vertices_p)[3 * i] = map[i1] - diff[map[i1]];
+        (*tri_vertices_p)[3 * i + 1] = map[i2] - diff[map[i2]];
+        (*tri_vertices_p)[3 * i + 2] = map[i3] - diff[map[i3]];
+
+        const double* v1c = ((*vertices_p) + (*tri_vertices_p)[3 * i])->coord;
+        const double* v2c = ((*vertices_p) + (*tri_vertices_p)[3 * i + 1])->coord;
+        const double* v3c = ((*vertices_p) + (*tri_vertices_p)[3 * i + 2])->coord;
+
+        if (!misAlignment(v1c, v2c, v3c))
+        {
+            ip_error("Model has degenerate triangles. Unsupported!\n");
+            (*ntri)--;
+        }
+        else i++;
+    }
+    free(map);
+    free(diff);
+
+    qsort((*tri_vertices_p), *ntri, sizeof(uint32_t) * 3, triOrder);
+    uint32_t num_duplicates = 0;
+    for (uint32_t i = 0; i < *ntri - 1; i++) if (triOrder((*tri_vertices_p) + i * 3, (*tri_vertices_p) + (i + 1) * 3) == 0) {
+        (*tri_vertices_p)[i * 3] = (*tri_vertices_p)[i * 3 + 1] = (*tri_vertices_p)[i * 3 + 2] = UINT32_MAX;
+        num_duplicates++;
+    }
+    qsort((*tri_vertices_p), *ntri, sizeof(uint32_t) * 3, triOrder);
+    *ntri -= num_duplicates;
+
+    if (verbose) std::cout << "Using " << *ntri << " non-degenerate constraints\n";
+}
+
+uint32_t inputPLC::numVertices() const { return (uint32_t)coordinates.size() / 3; }
+uint32_t inputPLC::numTriangles() const { return (uint32_t)triangle_vertices.size() / 3; }
+
+inputPLC::inputPLC() {}
+
+inputPLC::inputPLC(const char* filename) { initFromFile(filename, true); }
+
+bool inputPLC::initFromFile(const char* filename, bool verbose) {
+    input_file_name = filename;
+
+    // Read OFF file (only triangles supported)
+    uint32_t npts, ntri;
+    double* vertex_p;
+    uint32_t* tri_vertices_p;
+    read_OFF_file(filename, &vertex_p, &npts, &tri_vertices_p, &ntri, verbose);
+    if (verbose) printf("File read\n");
+    if (npts == 0) ip_error("Input file has no vertices\n");
+    if (ntri == 0) ip_error("Input file has no triangles\n");
+
+    postProcess(vertex_p, npts, tri_vertices_p, ntri, verbose);
+
+    free(vertex_p);
+    free(tri_vertices_p);
+
+    return true;
+}
+
+bool inputPLC::initFromVectors(double* vertex_p, uint32_t npts, uint32_t* tri_vertices_p, uint32_t ntri, bool verbose) {
+    input_file_name = "";
+
+    postProcess(vertex_p, npts, tri_vertices_p, ntri, verbose);
+
+    return true;
+}
+
+void inputPLC::postProcess(double* vertices_p, uint32_t npts, uint32_t* tri_vertices_p, uint32_t ntri, bool verbose) {
+    // Convert OFF to valid set of vertices (no duplications) and constraints (no degeneracies)
+    uint32_t* valid_tri_vertices_p;
+    uint32_t num_valid_tris;
+    input_vertex_t* tmp_vertices; // These have floating point coordinates
+    uint32_t num_vertices;
+    read_nodes_and_constraints(vertices_p, npts, tri_vertices_p, ntri, &tmp_vertices, &num_vertices, &valid_tri_vertices_p, &num_valid_tris, verbose);
+    if (verbose) printf("Valid input built\n");
+    if (num_vertices == 0) ip_error("Input file has no valid vertices\n");
+    if (num_valid_tris == 0) ip_error("Input file has no valid triangles\n");
+
+    coordinates.resize(3 * num_vertices);
+    for (uint32_t i = 0; i < num_vertices; i++) {
+        coordinates[i * 3] = tmp_vertices[i].coord[0];
+        coordinates[i * 3 + 1] = tmp_vertices[i].coord[1];
+        coordinates[i * 3 + 2] = tmp_vertices[i].coord[2];
+    }
+
+    triangle_vertices.assign(valid_tri_vertices_p, valid_tri_vertices_p + (num_valid_tris * 3));
+
+    free(tmp_vertices);
+    free(valid_tri_vertices_p);
+
+    reorderVertices(coordinates.data(), (uint32_t)coordinates.size() / 3, triangle_vertices.data(), (uint32_t)triangle_vertices.size() / 3);
+}
+
+// Add eight vertices to enclose the input in a box
+void inputPLC::addBoundingBoxVertices() {
+    double bbmin[3] = { DBL_MAX, DBL_MAX, DBL_MAX };
+    double bbmax[3] = { -DBL_MAX, -DBL_MAX, -DBL_MAX };
+    for (uint32_t i = 0; i < numVertices(); i++) {
+        const double *v = coordinates.data() + i * 3;
+        for (int j = 0; j < 3; j++) {
+            if (v[j] < bbmin[j]) bbmin[j] = v[j];
+            if (v[j] > bbmax[j]) bbmax[j] = v[j];
+        }
+    }
+    const double bbox[3] = { bbmax[0] - bbmin[0], bbmax[1] - bbmin[1], bbmax[2] - bbmin[2] };
+    for (int j = 0; j < 3; j++) {
+        bbmin[j] -= bbox[j] * 0.05;
+        bbmax[j] += bbox[j] * 0.05;
+    }
+
+    const int idx[] = { 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1 };
+
+    for (int j = 0; j < 24; j++)
+        coordinates.push_back(idx[j] ? (bbmax[j%3]) : (bbmin[j%3]));
+}

--- a/src/inputPLC.h
+++ b/src/inputPLC.h
@@ -1,8 +1,6 @@
 #include <iostream>
 #include <fstream>
 
-using namespace std;
-
 class reVertex {
 public:
     double c[3];

--- a/src/inputPLC.h
+++ b/src/inputPLC.h
@@ -1,5 +1,7 @@
-#include <iostream>
-#include <fstream>
+#ifndef INPUT_PLC_H
+#define INPUT_PLC_H
+
+#include <vector>
 #include "implicit_point.h"
 
 class reVertex {
@@ -22,222 +24,24 @@ public:
     vBlock(uint32_t b, uint32_t e, uint32_t d) : begin(b), end(e), dir_split(d) {}
 };
 
-void reorderVertices(double* coordinates, uint32_t numVertices, uint32_t* triVertices, uint32_t numTriangles) {
-    std::vector<reVertex> revertices; 
-    revertices.reserve(numVertices);
-    for (uint32_t i = 0; i < numVertices; i++) revertices.push_back(reVertex(coordinates + (i * 3), i));
-
-    std::vector<vBlock> blocks;
-    blocks.push_back(vBlock(0, numVertices, 0));
-
-    for (uint32_t b = 0; b < blocks.size(); b++) {
-        const vBlock block = blocks[b];
-        const uint32_t dir_split = block.dir_split;
-        if (dir_split == 0) std::sort(revertices.begin() + block.begin, revertices.begin() + block.end, reVertex::lessThanOnX);
-        else if (dir_split == 1) std::sort(revertices.begin() + block.begin, revertices.begin() + block.end, reVertex::lessThanOnY);
-        else std::sort(revertices.begin() + block.begin, revertices.begin() + block.end, reVertex::lessThanOnZ);
-        const uint32_t block_mid = (block.begin + block.end) >> 1;
-        if (block_mid != block.begin && block_mid != block.end) {
-            blocks.push_back(vBlock(block.begin, block_mid, (dir_split + 1) % 3));
-            blocks.push_back(vBlock(block_mid, block.end, (dir_split + 1) % 3));
-        }
-    }
-
-    std::vector<uint32_t> new_index(numVertices);
-    for (uint32_t i = 0; i < numVertices; i++) new_index[revertices[i].index] = i;
-
-    for (uint32_t i = 0; i < numTriangles * 3; i++) triVertices[i] = new_index[triVertices[i]];
-    for (uint32_t i = 0; i < numVertices; i++) {
-        const double* pt = revertices[i].c;
-        coordinates[i * 3] = pt[0];
-        coordinates[i * 3 + 1] = pt[1];
-        coordinates[i * 3 + 2] = pt[2];
-    }
-}
-
 struct input_vertex_t {
 public:
     double coord[3];          // Coordinates
     uint32_t original_index;  // Index to support reordering
 };
 
-bool misAlignment(const double* p, const double* q, const double* r)
-{
-    return orient2d(p[0], p[1], q[0], q[1], r[0], r[1]) ||
-        orient2d(p[1], p[2], q[1], q[2], r[1], r[2]) ||
-        orient2d(p[0], p[2], q[0], q[2], r[0], r[2]);
-}
-
-void read_OFF_file(const char* filename,
-    double** vertices_p, uint32_t* npts,
-    uint32_t** tri_vertices_p, uint32_t* ntri, bool verbose) {
-
-    FILE* file = fopen(filename, "r");
-    if (file == NULL)
-        ip_error("read_OFF_file: FATAL ERROR "
-            "cannot open input file.\n");
-
-    // Check OFF mark (1st line).
-    char file_ext_read[3];
-    char file_ext_target[] = { 'O','F','F' };
-    if (fscanf(file, "%3c", file_ext_read) == 0)
-        ip_error("read_OFF_file: FATAL ERROR "
-            "cannot read 1st line of input file\n");
-
-    for (uint32_t i = 0; i < 3; i++)
-        if (file_ext_read[i] != file_ext_target[i])
-            ip_error("read_OFF_file: FATAL ERROR "
-                "1st line of input file is different from OFF\n");
-
-    // Reading number of points and triangles.
-    if (fscanf(file, " %d %d %*d ", npts, ntri) == 0)
-        ip_error("read_OFF_file: FATAL ERROR 2st line of "
-            "input file do not contanins point and triangles numbers.\n");
-
-    if (verbose) std::cout << "file " << filename << " contains " << *npts << " vertices and " << *ntri << " constraints (triangles)\n";
-
-    // Reading points coordinates.
-    *vertices_p = (double*)malloc(sizeof(double) * 3 * (*npts));
-    *tri_vertices_p = (uint32_t*)malloc(sizeof(uint32_t) * 3 * (*ntri));
-
-    for (uint32_t i = 0; i < (*npts); i++) {
-        if (fscanf(file, " %lf %lf %lf ",
-            (*vertices_p) + (i * 3), (*vertices_p) + (i * 3 + 1), (*vertices_p) + (i * 3 + 2)) == 0)
-            ip_error("error reading input file\n");
-    }
-
-    uint32_t nv;
-    for (uint32_t i = 0; i < (*ntri); i++) {
-        if (fscanf(file, " %u %u %u %u ", &nv,
-            (*tri_vertices_p) + (i * 3), (*tri_vertices_p) + (i * 3 + 1), (*tri_vertices_p) + (i * 3 + 2)) == 0)
-            ip_error("error reading input file\n");
-        if (nv != 3) ip_error("Non-triangular faces not supported\n");
-    }
-    fclose(file);
-}
-
-int vertex_compare(const void* void_v1, const void* void_v2)
-{
-    const input_vertex_t* v1 = (input_vertex_t*)void_v1;
-    const input_vertex_t* v2 = (input_vertex_t*)void_v2;
-    const double dx = v1->coord[0] - v2->coord[0];
-    const double dy = v1->coord[1] - v2->coord[1];
-    const double dz = v1->coord[2] - v2->coord[2];
-    return (4 * ((dx > 0) - (dx < 0)) +
-        2 * ((dy > 0) - (dy < 0)) +
-        ((dz > 0) - (dz < 0)));
-}
-
-int triOrder(const void* t1, const void* t2) {
-    const uint32_t* a = (uint32_t*)t1;
-    const uint32_t* b = (uint32_t*)t2;
-
-    // Here we should pre-order a[3] and b[3] to identify coincident triangles with different vertex ordering!!!
-    // To be done!
-    if (a[0] < b[0]) return -1;
-    if (a[0] > b[0]) return 1;
-    if (a[1] < b[1]) return -1;
-    if (a[1] > b[1]) return 1;
-    if (a[2] < b[2]) return -1;
-    return (a[2] > b[2]);
-}
-
-inline bool coincident_points(const input_vertex_t* a, const input_vertex_t* b)
-{
-    return !vertex_compare(a->coord, b->coord);
-}
-
+void reorderVertices(double* coordinates, uint32_t numVertices, uint32_t* triVertices, uint32_t numTriangles);
+bool misAlignment(const double* p, const double* q, const double* r);
+void read_OFF_file(const char* filename, double** vertices_p, uint32_t* npts, uint32_t** tri_vertices_p, uint32_t* ntri, bool verbose);
+int vertex_compare(const void* void_v1, const void* void_v2);
+int triOrder(const void* t1, const void* t2);
+bool coincident_points(const input_vertex_t* a, const input_vertex_t* b);
 void remove_duplicated_points(input_vertex_t** vertices_p, uint32_t* npts,
     input_vertex_t* vrts_copy,
-    uint32_t* map, uint32_t* diff) {
-
-    // Sorting vertices by coordinates lexicographic order (x,y,z)
-    qsort(vrts_copy, *npts, sizeof(input_vertex_t), vertex_compare);
-
-    // Count and memory position of duplicated vertices.
-    uint32_t vrts_counter = 0;
-    for (uint32_t i = 1; i < (*npts); i++) {
-        if (coincident_points(vrts_copy + i - 1, vrts_copy + i)) vrts_counter++;
-        diff[i] = vrts_counter;
-    }
-
-    // Set original_index to follow vertices permutation.
-    for (uint32_t i = 0; i < (*npts); i++)  map[vrts_copy[i].original_index] = i;
-
-    // Allocating memory to store uinque mesh vertices (vertices_p).
-    *vertices_p = (input_vertex_t*)malloc(sizeof(input_vertex_t) * (*npts - vrts_counter));
-
-    // Fill mesh vertices (vertices_p)
-    memcpy(*vertices_p, vrts_copy, sizeof(input_vertex_t));
-    for (uint32_t i = vrts_counter = 1; i < (*npts); i++)
-        if (!coincident_points(vrts_copy + i - 1, vrts_copy + i))
-            memcpy(*vertices_p + (vrts_counter++), vrts_copy + i, sizeof(input_vertex_t));
-
-    // Update uinque vertices number.
-    (*npts) = vrts_counter;
-}
-
-
-/// //////////////////////////////////////////////////////////////////////////////////////////
-
+    uint32_t* map, uint32_t* diff);
 void read_nodes_and_constraints(double* coords_A, uint32_t npts_A, uint32_t* tri_idx_A, uint32_t ntri_A,
     input_vertex_t** vertices_p, uint32_t* npts,
-    uint32_t** tri_vertices_p, uint32_t* ntri, bool verbose) {
-
-    // Reading points coordinates.
-    *npts = npts_A;
-    *ntri = ntri_A;
-    input_vertex_t* tmp = (input_vertex_t*)malloc(*npts * sizeof(input_vertex_t));
-    uint32_t* diff = (uint32_t*)calloc(*npts, sizeof(uint32_t));
-    uint32_t* map = (uint32_t*)malloc(*npts * sizeof(uint32_t));
-    *tri_vertices_p = (uint32_t*)malloc(sizeof(uint32_t) * 3 * (*ntri));
-
-    for (uint32_t i = 0; i < (*npts); i++) {
-        tmp[i].coord[0] = coords_A[i * 3];
-        tmp[i].coord[1] = coords_A[i * 3 + 1];
-        tmp[i].coord[2] = coords_A[i * 3 + 2];
-        tmp[i].original_index = i;
-    }
-
-    if (*npts > 1) remove_duplicated_points(vertices_p, npts, tmp, map, diff);
-    if (verbose) std::cout << "Using " << *npts << " unique vertices\n";
-
-    free(tmp);
-
-    for (uint32_t i = 0, j = 0; i < (*ntri); j++) {
-
-        const uint32_t i1 = tri_idx_A[j * 3];
-        const uint32_t i2 = tri_idx_A[j * 3 + 1];
-        const uint32_t i3 = tri_idx_A[j * 3 + 2];
-        (*tri_vertices_p)[3 * i] = map[i1] - diff[map[i1]];
-        (*tri_vertices_p)[3 * i + 1] = map[i2] - diff[map[i2]];
-        (*tri_vertices_p)[3 * i + 2] = map[i3] - diff[map[i3]];
-
-        const double* v1c = ((*vertices_p) + (*tri_vertices_p)[3 * i])->coord;
-        const double* v2c = ((*vertices_p) + (*tri_vertices_p)[3 * i + 1])->coord;
-        const double* v3c = ((*vertices_p) + (*tri_vertices_p)[3 * i + 2])->coord;
-
-        if (!misAlignment(v1c, v2c, v3c))
-        {
-            ip_error("Model has degenerate triangles. Unsupported!\n");
-            (*ntri)--;
-        }
-        else i++;
-    }
-    free(map);
-    free(diff);
-
-    qsort((*tri_vertices_p), *ntri, sizeof(uint32_t) * 3, triOrder);
-    uint32_t num_duplicates = 0;
-    for (uint32_t i = 0; i < *ntri - 1; i++) if (triOrder((*tri_vertices_p) + i * 3, (*tri_vertices_p) + (i + 1) * 3) == 0) {
-        (*tri_vertices_p)[i * 3] = (*tri_vertices_p)[i * 3 + 1] = (*tri_vertices_p)[i * 3 + 2] = UINT32_MAX;
-        num_duplicates++;
-    }
-    qsort((*tri_vertices_p), *ntri, sizeof(uint32_t) * 3, triOrder);
-    *ntri -= num_duplicates;
-
-    if (verbose) std::cout << "Using " << *ntri << " non-degenerate constraints\n";
-}
+    uint32_t** tri_vertices_p, uint32_t* ntri, bool verbose);
 
 class inputPLC {
 public:
@@ -245,87 +49,16 @@ public:
     std::vector<uint32_t> triangle_vertices; // t1_v1, t1_v2, t1_v3, t2_v1, t2_v2, ...
     const char* input_file_name;
 
-    uint32_t numVertices() const { return (uint32_t)coordinates.size() / 3; }
-    uint32_t numTriangles() const { return (uint32_t)triangle_vertices.size() / 3; }
+    uint32_t numVertices() const;
+    uint32_t numTriangles() const;
 
-    inputPLC() {}
+    inputPLC();
+    inputPLC(const char* filename);
 
-    inputPLC(const char* filename) { initFromFile(filename, true); }
-
-    bool initFromFile(const char* filename, bool verbose) {
-        input_file_name = filename;
-
-        // Read OFF file (only triangles supported)
-        uint32_t npts, ntri;
-        double* vertex_p;
-        uint32_t* tri_vertices_p;
-        read_OFF_file(filename, &vertex_p, &npts, &tri_vertices_p, &ntri, verbose);
-        if (verbose) printf("File read\n");
-        if (npts == 0) ip_error("Input file has no vertices\n");
-        if (ntri == 0) ip_error("Input file has no triangles\n");
-
-        postProcess(vertex_p, npts, tri_vertices_p, ntri, verbose);
-
-        free(vertex_p);
-        free(tri_vertices_p);
-
-        return true;
-    }
-
-    bool initFromVectors(double* vertex_p, uint32_t npts, uint32_t* tri_vertices_p, uint32_t ntri, bool verbose) {
-        input_file_name = "";
-
-        postProcess(vertex_p, npts, tri_vertices_p, ntri, verbose);
-
-        return true;
-    }
-
-    void postProcess(double* vertices_p, uint32_t npts, uint32_t* tri_vertices_p, uint32_t ntri, bool verbose) {
-        // Convert OFF to valid set of vertices (no duplications) and constraints (no degeneracies)
-        uint32_t* valid_tri_vertices_p;
-        uint32_t num_valid_tris;
-        input_vertex_t* tmp_vertices; // These have floating point coordinates
-        uint32_t num_vertices;
-        read_nodes_and_constraints(vertices_p, npts, tri_vertices_p, ntri, &tmp_vertices, &num_vertices, &valid_tri_vertices_p, &num_valid_tris, verbose);
-        if (verbose) printf("Valid input built\n");
-        if (num_vertices == 0) ip_error("Input file has no valid vertices\n");
-        if (num_valid_tris == 0) ip_error("Input file has no valid triangles\n");
-
-        coordinates.resize(3 * num_vertices);
-        for (uint32_t i = 0; i < num_vertices; i++) {
-            coordinates[i * 3] = tmp_vertices[i].coord[0];
-            coordinates[i * 3 + 1] = tmp_vertices[i].coord[1];
-            coordinates[i * 3 + 2] = tmp_vertices[i].coord[2];
-        }
-
-        triangle_vertices.assign(valid_tri_vertices_p, valid_tri_vertices_p + (num_valid_tris * 3));
-
-        free(tmp_vertices);
-        free(valid_tri_vertices_p);
-
-        reorderVertices(coordinates.data(), (uint32_t)coordinates.size() / 3, triangle_vertices.data(), (uint32_t)triangle_vertices.size() / 3);
-    }
-
-    // Add eight vertices to enclose the input in a box
-    void addBoundingBoxVertices() {
-        double bbmin[3] = { DBL_MAX, DBL_MAX, DBL_MAX };
-        double bbmax[3] = { -DBL_MAX, -DBL_MAX, -DBL_MAX };
-        for (uint32_t i = 0; i < numVertices(); i++) {
-            const double *v = coordinates.data() + i * 3;
-            for (int j = 0; j < 3; j++) {
-                if (v[j] < bbmin[j]) bbmin[j] = v[j];
-                if (v[j] > bbmax[j]) bbmax[j] = v[j];
-            }
-        }
-        const double bbox[3] = { bbmax[0] - bbmin[0], bbmax[1] - bbmin[1], bbmax[2] - bbmin[2] };
-        for (int j = 0; j < 3; j++) {
-            bbmin[j] -= bbox[j] * 0.05;
-            bbmax[j] += bbox[j] * 0.05;
-        }
-
-        const int idx[] = { 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1 };
-
-        for (int j = 0; j < 24; j++)
-            coordinates.push_back(idx[j] ? (bbmax[j%3]) : (bbmin[j%3]));
-    }
+    bool initFromFile(const char* filename, bool verbose);
+    bool initFromVectors(double* vertex_p, uint32_t npts, uint32_t* tri_vertices_p, uint32_t ntri, bool verbose);
+    void postProcess(double* vertices_p, uint32_t npts, uint32_t* tri_vertices_p, uint32_t ntri, bool verbose);
+    void addBoundingBoxVertices();
 };
+
+#endif // INPUT_PLC_H

--- a/src/inputPLC.h
+++ b/src/inputPLC.h
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <fstream>
+#include "implicit_point.h"
 
 class reVertex {
 public:

--- a/src/logger.h
+++ b/src/logger.h
@@ -1,8 +1,8 @@
 #include <chrono>
 #include <cstring>
 
-inline FILE* log_fp;
-inline std::chrono::steady_clock::time_point time_point;
+FILE* log_fp;
+std::chrono::steady_clock::time_point time_point;
 
 inline void startLogging(const char* fn) {
     if (fn != NULL) {
@@ -59,7 +59,7 @@ inline void finishLogging() {
 // To ensure correct resolution of symbols, add Psapi.lib to TARGETLIBS
 // and compile with -DPSAPI_VERSION=1
 
-inline double getPeakMegabytesUsed()
+double getPeakMegabytesUsed()
 {
     HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, GetCurrentProcessId());
     if (NULL == hProcess) return 0;

--- a/src/logger.h
+++ b/src/logger.h
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <cstring>
 
 inline FILE* log_fp;
 inline std::chrono::steady_clock::time_point time_point;

--- a/src/logger.h
+++ b/src/logger.h
@@ -1,7 +1,7 @@
 #include <chrono>
 
-FILE* log_fp;
-std::chrono::steady_clock::time_point time_point;
+inline FILE* log_fp;
+inline std::chrono::steady_clock::time_point time_point;
 
 inline void startLogging(const char* fn) {
     if (fn != NULL) {
@@ -58,7 +58,7 @@ inline void finishLogging() {
 // To ensure correct resolution of symbols, add Psapi.lib to TARGETLIBS
 // and compile with -DPSAPI_VERSION=1
 
-double getPeakMegabytesUsed()
+inline double getPeakMegabytesUsed()
 {
     HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, GetCurrentProcessId());
     if (NULL == hProcess) return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,8 +8,6 @@
 #include "inputPLC.h"
 #include "PLC.h"
 
-using namespace std;
-
 #include "logger.h"
 
 // createSteinerCDT


### PR DESCRIPTION
I've made a couple of changes to improve usability of this library in my project:

- Removed all `using namespace std` (and variants)
- Included `implicit_point` header in `inputPLC` for `orient2d`
- Added inline keywords in `logger.h`
- Created a dedicated header file for `inputPLC`
- Added missing std includes in `inputPLC`

I'll confirm if those inline keywords are really necessary by tomorrow morning.